### PR TITLE
use native path resolver

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -13,7 +13,8 @@ export async function activate(context: ExtensionContext): Promise<void> {
     return
   }
 
-  const serverModule = context.asAbsolutePath(path.join('node_modules', 'dockerfile-language-server-nodejs', 'lib', 'server.js'))
+  //const serverModule = context.asAbsolutePath(path.join('node_modules', 'dockerfile-language-server-nodejs', 'lib', 'server.js'))
+  const serverModule = require.resolve('dockerfile-language-server-nodejs/lib/server.js')
 
   const serverOptions: ServerOptions = {
     module: serverModule,


### PR DESCRIPTION
partially fix #45 .

In a certain situation the dependencies are not in the expected location:

```text
~/.config/coc/extensions
|
— node_modules
    |
    — coc-docker
    — dockerfile-language-server-nodejs
```

This is the case if the coc-docker is installed directly using `cd ~/.config/coc/extensions && yarn add coc-docker`. In this case, the path to `dockerfile-language-server-nodejs` is not as expected in the old code.

Simply switching to the native module resolver solves the issue.