### PR TITLE
support docker filetype

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   "activationEvents": [
     "onLanguage:Dockerfile",
     "onLanguage:dockerfile",
+    "onLanguage:docker",
     "onLanguage:yaml.docker-compose",
     "onCommand:docker.version"
   ],


### PR DESCRIPTION
I use coc.nvim and neovim, by default the filetype of Dockerfile.* is `docker` instead of `dockerfile`